### PR TITLE
Add Lex Fridman podcast RSS source

### DIFF
--- a/src/config/rss-config.js
+++ b/src/config/rss-config.js
@@ -133,6 +133,11 @@ export const config = {
       url: "https://www.formula1.com/content/fom-website/en/latest/all.xml",
       category: "体育资讯",
     },
+    {
+      name: "Lex Fridman Podcast",
+      url: "https://lexfridman.com/feed/podcast/",
+      category: "播客",
+    },
   ],
   maxItemsPerFeed: 30,
   dataPath: "./public/data",


### PR DESCRIPTION
## Summary
- add a new podcast category RSS source for Lex Fridman Podcast

## Verification
- git diff --check
- curl -L -I https://lexfridman.com/feed/podcast/
- pnpm build