### PR TITLE
Add multilingual support and improve source switching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 LLM_API_KEY=your_api_key
 LLM_API_BASE=https://api.siliconflow.cn/v1
 LLM_NAME=THUDM/GLM-4-9B-0414
+SUMMARY_LOCALES=zh,en

--- a/README.en.md
+++ b/README.en.md
@@ -71,6 +71,7 @@ This project uses GitHub Actions for automatic deployment to GitHub Pages, with 
    - `LLM_API_KEY`: API key for AI summary generation
    - `LLM_API_BASE`: API base URL for the LLM service
    - `LLM_NAME`: Name of the model to use
+   - `SUMMARY_LOCALES`: Comma-separated summary locales, defaults to `zh,en`
 
 3. **Enable GitHub Pages**
 
@@ -110,7 +111,7 @@ This project uses GitHub Actions for automatic deployment to GitHub Pages, with 
 - **Adjust Retained Items**: Modify the `maxItemsPerFeed` value in `src/config/rss-config.js`
 
 - **Customize Summary Generation**:
-  If you need to customize the summary generation method, such as following a specific format or switching the summary language, modify the `prompt` variable in `scripts/update-feeds.js`
+  To change summary languages, update `SUMMARY_LOCALES`, for example `zh`, `en`, or `zh,en`. To add another language, add locale metadata in `src/config/i18n-config.js` and provide matching localized labels/messages.
 
 ### Method 2: Vercel Deployment
 
@@ -192,6 +193,7 @@ This method uses Docker to run FeedMe locally or on a server. It utilizes an in-
    LLM_API_KEY=your_api_key
    LLM_API_BASE=LLM service API base URL (e.g., https://api.siliconflow.cn/v1)
    LLM_NAME=model name (e.g., THUDM/GLM-4-9B-0414)
+   SUMMARY_LOCALES=summary locales (e.g., zh,en)
    ```
    These environment variables are used to configure the article summary generation feature and need to be obtained from an LLM service provider
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
    - `LLM_API_KEY`: 用于 AI 摘要生成的 API 密钥
    - `LLM_API_BASE`: LLM 服务的 API 基础 URL
    - `LLM_NAME`: 使用的模型名称
+   - `SUMMARY_LOCALES`: 需要生成摘要的语言列表，默认 `zh,en`
 
 3. **启用 GitHub Pages**
    
@@ -110,7 +111,7 @@
 - **调整保留条目数**: 修改 `src/config/rss-config.js` 中的 `maxItemsPerFeed` 值
 
 - **自定义摘要生成**：
-  如果需要自定义摘要生成方法，比如遵循特定格式或切换摘要语言，请修改 `scripts/update-feeds.js` 中的 `prompt` 变量
+  如需调整摘要语言，请修改 `SUMMARY_LOCALES`，例如 `zh`、`en` 或 `zh,en`。如需新增语言，请在 `src/config/i18n-config.js` 中增加 locale 元数据，并在相关本地化配置中补充该语言文案。
 
 ### 方式二：Vercel 部署
 
@@ -192,6 +193,7 @@ GitHub Actions 每次构建后会自动推送到 `deploy` 分支，阿里云 ESA
    LLM_API_KEY=你的 API 密钥
    LLM_API_BASE=LLM服务的 API 基础 URL（例如：https://api.siliconflow.cn/v1）
    LLM_NAME=使用的模型名称（例如：THUDM/GLM-4-9B-0414）
+   SUMMARY_LOCALES=摘要语言列表（例如：zh,en）
    ```
    这些环境变量用于配置文章摘要生成功能，需要从 LLM 服务提供商获取
 

--- a/scripts/update-feeds.js
+++ b/scripts/update-feeds.js
@@ -10,6 +10,13 @@ import { OpenAI } from 'openai';
 
 // 从配置文件中导入RSS源配置
 import { config } from '../src/config/rss-config.js';
+import {
+  defaultLocale,
+  getLocaleMeta,
+  getLocalizedValue,
+  parseLocaleList,
+  supportedLocales,
+} from '../src/config/i18n-config.js';
 
 // 获取 __dirname 的 ES 模块等价物
 const __filename = fileURLToPath(import.meta.url);
@@ -67,6 +74,7 @@ const parser = new Parser({
 const OPENAI_API_KEY = process.env.LLM_API_KEY;
 const OPENAI_API_BASE = process.env.LLM_API_BASE;
 const OPENAI_MODEL_NAME = process.env.LLM_NAME;
+const SUMMARY_LOCALES = parseLocaleList(process.env.SUMMARY_LOCALES || process.env.SUMMARY_LANG, supportedLocales);
 
 // 验证必要的环境变量
 if (!OPENAI_API_KEY) {
@@ -137,8 +145,48 @@ function loadFeedData(sourceUrl) {
   }
 }
 
+const summaryUnavailableMessages = {
+  zh: "无法生成摘要。",
+  en: "Unable to generate summary.",
+};
+
+function getSummaryUnavailableMessage(locale) {
+  return getLocalizedValue(summaryUnavailableMessages, locale);
+}
+
+function normalizeSummaries(item = {}) {
+  const summaries = { ...(item.summaries || {}) };
+
+  if (item.summary && !summaries[defaultLocale]) {
+    summaries[defaultLocale] = item.summary;
+  }
+
+  return summaries;
+}
+
+function buildSummaryPrompt(title, content, locale) {
+  const { summaryLanguage } = getLocaleMeta(locale);
+
+  return `
+You are a professional content summarizer. Generate a concise and accurate summary in ${summaryLanguage}.
+The summary should:
+1. Capture the main points and key information.
+2. Be clear, fluent, and natural in ${summaryLanguage}.
+3. Stay around 100 words or fewer.
+4. Remain objective and avoid adding opinions.
+5. If the content is empty or lacks useful information, do not invent details.
+6. If the source title or content is in another language, summarize the key information in ${summaryLanguage}.
+
+Article title:
+${title}
+
+Article content:
+${content.slice(0, 5000)}
+`;
+}
+
 // 生成摘要函数
-async function generateSummary(title, content) {
+async function generateSummary(title, content, locale) {
   try {
     // 确保 content 不为空
     const contentToClean = content || "";
@@ -146,20 +194,7 @@ async function generateSummary(title, content) {
     const cleanContent = contentToClean.replace(/<[^>]*>?/gm, "");
 
     // 准备提示词
-    const prompt = `
-你是一个专业的内容摘要生成器。请根据以下文章标题和内容，生成一个简洁、准确的中文摘要。
-摘要应该：
-1. 捕捉文章的主要观点和关键信息
-2. 使用清晰、流畅的中文
-3. 长度控制在100字左右
-4. 保持客观，不添加个人观点
-5. 如果文章内容为空或不包含有效信息，不要生成文章标题或内容未提及的无关内容。对非中文的标题进行翻译，不需要翻译中文的标题
-
-文章标题：${title}
-
-文章内容：
-${cleanContent.slice(0, 5000)} // 限制内容长度以避免超出token限制
-`;
+    const prompt = buildSummaryPrompt(title, cleanContent, locale);
 
     const completion = await openai.chat.completions.create({
       model: OPENAI_MODEL_NAME,
@@ -173,10 +208,10 @@ ${cleanContent.slice(0, 5000)} // 限制内容长度以避免超出token限制
       max_tokens: 500,
     });
 
-    return completion.choices[0].message.content?.trim() || "无法生成摘要。";
+    return completion.choices[0].message.content?.trim() || getSummaryUnavailableMessage(locale);
   } catch (error) {
     console.error("生成摘要时出错:", error);
-    return "无法生成摘要。AI 模型暂时不可用。";
+    return getSummaryUnavailableMessage(locale);
   }
 }
 
@@ -259,10 +294,16 @@ function mergeFeedItems(oldItems = [], newItems = [], maxItems = config.maxItems
         item.summary = undefined; // 清除原始的 summary，避免与我们的生成摘要混淆
       }
 
+      const summaries = {
+        ...normalizeSummaries(item),
+        ...normalizeSummaries(existingItem),
+      };
+
       const serializedItem = {
         ...item,
         content: item.content || existingItem?.content || "",
-        summary: generatedSummary || item.summary, // 保留已生成的摘要
+        summaries,
+        summary: summaries[defaultLocale] || generatedSummary || item.summary, // 保留旧字段兼容
       };
 
       itemsMap.set(item.link, serializedItem);
@@ -302,20 +343,48 @@ async function updateFeed(sourceUrl) {
     // 为新条目生成摘要
     const itemsWithSummaries = await Promise.all(
       mergedItems.map(async (item) => {
+        const summaries = normalizeSummaries(item);
+
         // 如果是新条目且需要生成摘要
-        if (newItemsForSummary.some((newItem) => newItem.link === item.link) && !item.summary) {
+        if (newItemsForSummary.some((newItem) => newItem.link === item.link)) {
           try {
             // 确保使用任何可用的内容源 - content, item 本身的 summary 字段, 或 contentSnippet
             const contentForSummary = item.content || item.contentSnippet || "";
-            const summary = await generateSummary(item.title, contentForSummary);
-            return { ...item, summary };
+            const generatedSummaries = await Promise.all(
+              SUMMARY_LOCALES.map(async (locale) => {
+                if (summaries[locale]) {
+                  return [locale, summaries[locale]];
+                }
+
+                const summary = await generateSummary(item.title, contentForSummary, locale);
+                return [locale, summary];
+              }),
+            );
+
+            for (const [locale, summary] of generatedSummaries) {
+              summaries[locale] = summary;
+            }
+
+            return {
+              ...item,
+              summaries,
+              summary: summaries[defaultLocale] || summaries[SUMMARY_LOCALES[0]] || item.summary,
+            };
           } catch (err) {
             console.error(`为条目 ${item.title} 生成摘要时出错:`, err);
-            return { ...item, summary: "无法生成摘要。" };
+            return {
+              ...item,
+              summaries,
+              summary: summaries[defaultLocale] || getSummaryUnavailableMessage(defaultLocale),
+            };
           }
         }
         // 否则保持不变
-        return item;
+        return {
+          ...item,
+          summaries,
+          summary: summaries[defaultLocale] || item.summary,
+        };
       }),
     );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,7 @@ function AppContent() {
           <p className="text-muted-foreground mb-8">{t("app.tagline")}</p>
 
           <div className="mb-8">
-            <Suspense fallback={<div className="w-full md:w-[300px] h-10 bg-muted rounded-md animate-pulse" />}>
+            <Suspense fallback={<div className="w-full md:w-[340px] h-10 bg-muted rounded-md animate-pulse" />}>
               <SourceSwitcher />
             </Suspense>
           </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,14 +3,27 @@ import { ThemeProvider } from '@/components/theme-provider';
 import { RssFeed } from '@/components/rss-feed';
 import { SourceSwitcher } from '@/components/source-switcher';
 import { ThemeToggle } from '@/components/theme-toggle';
+import { LanguageToggle } from '@/components/language-toggle';
 import { ScrollToTop } from '@/components/scroll-to-top';
 import { defaultSource } from '@/config/rss-config';
+import { I18nProvider, useI18n } from '@/i18n';
 import { Github } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 function App() {
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+    <I18nProvider>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+        <AppContent />
+      </ThemeProvider>
+    </I18nProvider>
+  );
+}
+
+function AppContent() {
+  const { t } = useI18n()
+
+  return (
       <main className="min-h-screen bg-background">
         <div className="container py-10 mx-auto max-w-4xl">
           <div className="flex justify-between items-center mb-6">
@@ -18,21 +31,22 @@ function App() {
               😋FeedMe
             </a>
             <div className="flex items-center gap-2">
+              <LanguageToggle />
               <ThemeToggle />
               <a
                 href="https://github.com/Seanium/feedme"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="GitHub 仓库"
+                aria-label={t("app.github")}
               >
                 <Button variant="outline" size="icon" className="relative">
                   <Github className="h-[1.2rem] w-[1.2rem]" />
-                  <span className="sr-only">GitHub 仓库</span>
+                  <span className="sr-only">{t("app.github")}</span>
                 </Button>
               </a>
             </div>
           </div>
-          <p className="text-muted-foreground mb-8">从多个信息源获取最新内容，由 AI 生成摘要</p>
+          <p className="text-muted-foreground mb-8">{t("app.tagline")}</p>
 
           <div className="mb-8">
             <Suspense fallback={<div className="w-full md:w-[300px] h-10 bg-muted rounded-md animate-pulse" />}>
@@ -47,12 +61,11 @@ function App() {
 
         <footer className="border-t border-border">
           <div className="container mx-auto max-w-4xl py-6">
-            <p className="text-center text-sm text-muted-foreground">Stay hungry. 😋</p>
+            <p className="text-center text-sm text-muted-foreground">{t("app.footer")}</p>
           </div>
         </footer>
         <ScrollToTop />
       </main>
-    </ThemeProvider>
   );
 }
 

--- a/src/components/language-toggle.tsx
+++ b/src/components/language-toggle.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { Languages } from "lucide-react"
+import { useRef } from "react"
+import { Button } from "@/components/ui/button"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { localeLabels, localeOptions, useI18n, type Locale } from "@/i18n"
+
+export function LanguageToggle() {
+  const { locale, setLocale, t } = useI18n()
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const closeFromPointerRef = useRef(false)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button ref={triggerRef} variant="outline" size="icon" className="relative">
+          <Languages className="h-[1.2rem] w-[1.2rem]" />
+          <span className="sr-only">{t("language.toggle")}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        onCloseAutoFocus={(event) => {
+          if (!closeFromPointerRef.current) {
+            return
+          }
+
+          event.preventDefault()
+          triggerRef.current?.blur()
+          closeFromPointerRef.current = false
+        }}
+      >
+        {localeOptions.map((nextLocale: Locale) => (
+          <DropdownMenuItem
+            key={nextLocale}
+            onPointerDown={() => {
+              closeFromPointerRef.current = true
+            }}
+            onClick={() => setLocale(nextLocale)}
+          >
+            {localeLabels[nextLocale]}
+            {locale === nextLocale && " ✓"}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/components/rss-feed.tsx
+++ b/src/components/rss-feed.tsx
@@ -8,12 +8,14 @@ import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { loadFeedData } from "@/lib/data-store"
 import type { FeedData } from "@/lib/types"
-import { findSourceByUrl } from "@/config/rss-config"
+import { findSourceByUrl, getCategoryName, getSourceName } from "@/config/rss-config"
+import { dateLocales, useI18n } from "@/i18n"
 import { ExternalLink } from "lucide-react"
 
 export function RssFeed({ defaultSource }: { defaultSource: string }) {
   const searchParams = useSearchParams()
   const sourceUrl = searchParams.get("source") || defaultSource
+  const { locale, t } = useI18n()
 
   const [feedData, setFeedData] = useState<FeedData | null>(null)
   const [loading, setLoading] = useState(true)
@@ -29,11 +31,11 @@ export function RssFeed({ defaultSource }: { defaultSource: string }) {
       if (cachedData) {
         setFeedData(cachedData)
       } else {
-        setError("数据为空，请检查数据源是否出错🫠")
+        setError(t("feed.emptyData"))
       }
     } catch (err) {
       console.error("Error fetching feed:", err)
-      setError("数据获取失败，请检查数据源是否出错🫠")
+      setError(t("feed.fetchError"))
     } finally {
       setLoading(false)
     }
@@ -41,10 +43,10 @@ export function RssFeed({ defaultSource }: { defaultSource: string }) {
 
   useEffect(() => {
     fetchFeed(sourceUrl)
-  }, [sourceUrl])
+  }, [sourceUrl, t])
 
   const source = findSourceByUrl(sourceUrl)
-  const displayTitle = source?.name || feedData?.title || "信息源"
+  const displayTitle = source ? getSourceName(source, locale) : feedData?.title || t("feed.sourceFallback")
 
   if (error) {
     return (
@@ -61,10 +63,10 @@ export function RssFeed({ defaultSource }: { defaultSource: string }) {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <h2 className="text-2xl font-bold">{displayTitle}</h2>
-          {source && <Badge variant="outline">{source.category}</Badge>}
+          {source && <Badge variant="outline">{getCategoryName(source.category, locale)}</Badge>}
           {feedData?.lastUpdated && (
             <span className="text-xs text-muted-foreground">
-              更新于: {new Date(feedData.lastUpdated).toLocaleString("zh-CN")}
+              {t("feed.updatedAt")}: {new Date(feedData.lastUpdated).toLocaleString(dateLocales[locale])}
             </span>
           )}
         </div>
@@ -108,25 +110,27 @@ export function RssFeed({ defaultSource }: { defaultSource: string }) {
                   </a>
                 </CardTitle>
                 <CardDescription>
-                  {new Date(item.pubDate || item.isoDate || "").toLocaleString("zh-CN")}
+                  {new Date(item.pubDate || item.isoDate || "").toLocaleString(dateLocales[locale])}
                   {item.creator && ` · ${item.creator}`}
                 </CardDescription>
               </CardHeader>
               <CardContent>
                 <Tabs defaultValue="summary">
                   <TabsList className="mb-4">
-                    <TabsTrigger value="summary">AI 摘要</TabsTrigger>
-                    <TabsTrigger value="original">原文内容</TabsTrigger>
+                    <TabsTrigger value="summary">{t("feed.summary")}</TabsTrigger>
+                    <TabsTrigger value="original">{t("feed.original")}</TabsTrigger>
                   </TabsList>
                   <TabsContent value="summary" className="space-y-2">
-                    <div className="text-sm text-muted-foreground mb-2">由 AI 生成的摘要：</div>
-                    <div className="text-foreground whitespace-pre-line">{item.summary || "无法生成摘要。"}</div>
+                    <div className="text-sm text-muted-foreground mb-2">{t("feed.summaryGeneratedByAi")}</div>
+                    <div className="text-foreground whitespace-pre-line">
+                      {item.summaries?.[locale] || item.summary || t("feed.summaryUnavailable")}
+                    </div>
                   </TabsContent>
                   <TabsContent value="original">
                     <div
                       className="text-sm prose prose-sm max-w-none"
                       dangerouslySetInnerHTML={{
-                        __html: item.content || item.contentSnippet || "无内容",
+                        __html: item.content || item.contentSnippet || t("feed.noContent"),
                       }}
                     />
                   </TabsContent>

--- a/src/components/scroll-to-top.tsx
+++ b/src/components/scroll-to-top.tsx
@@ -3,8 +3,10 @@
 import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { ArrowUp } from "lucide-react"
+import { useI18n } from "@/i18n"
 
 export function ScrollToTop() {
+  const { t } = useI18n()
   const [isVisible, setIsVisible] = useState(false)
 
   // 监听滚动事件，决定按钮是否可见
@@ -39,7 +41,7 @@ export function ScrollToTop() {
           onClick={scrollToTop}
           className="fixed bottom-8 right-8 z-50 rounded-full p-3 shadow-lg transition-all duration-300 hover:shadow-xl"
           size="icon"
-          aria-label="返回顶部"
+          aria-label={t("scrollToTop.label")}
         >
           <ArrowUp className="h-5 w-5" />
         </Button>

--- a/src/components/source-switcher.tsx
+++ b/src/components/source-switcher.tsx
@@ -7,18 +7,27 @@ import { Button } from "@/components/ui/button"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { useState } from "react"
-import { getSourcesByCategory, findSourceByUrl, type RssSource } from "@/config/rss-config"
+import { getSourceName, getSourcesByCategory, findSourceByUrl } from "@/config/rss-config"
+import { useI18n } from "@/i18n"
+
+type RssSource = {
+  url: string
+  name: Record<string, string>
+  category: string
+}
 
 export function SourceSwitcher() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const currentSource = searchParams.get("source")
+  const { locale, t } = useI18n()
 
   const [open, setOpen] = useState(false)
 
   const handleSelect = (source: RssSource) => {
     const params = new URLSearchParams(searchParams)
     params.set("source", source.url)
+    params.set("lang", locale)
     // 使用当前页面路径，保留 basePath
     const currentPath = window.location.pathname
     router.push(`${currentPath}?${params.toString()}`)
@@ -26,10 +35,11 @@ export function SourceSwitcher() {
   }
 
   // 按类别分组源
-  const groupedSources = getSourcesByCategory()
+  const groupedSources = getSourcesByCategory(locale)
 
   // 查找当前源名称
-  const currentSourceName = currentSource ? findSourceByUrl(currentSource)?.name || "选择信息源" : "选择信息源"
+  const currentSourceData = currentSource ? findSourceByUrl(currentSource) : undefined
+  const currentSourceName = currentSourceData ? getSourceName(currentSourceData, locale) : t("sourceSwitcher.select")
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -44,19 +54,22 @@ export function SourceSwitcher() {
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <Command>
-          <CommandInput placeholder="搜索信息源..." autoFocus={false} />
+          <CommandInput placeholder={t("sourceSwitcher.search")} autoFocus={false} />
           <CommandList>
-            <CommandEmpty>未找到匹配的信息源</CommandEmpty>
-            {Object.entries(groupedSources).map(([category, categorySources]) => {
-              const sources = categorySources as RssSource[];
+            <CommandEmpty>{t("sourceSwitcher.empty")}</CommandEmpty>
+            {Object.entries(groupedSources).map(([category, group]) => {
+              const { label, sources } = group as { label: string; sources: RssSource[] };
               return (
-                <CommandGroup key={category} heading={category}>
-                  {sources.map((source: RssSource) => (
-                    <CommandItem key={source.url} value={source.name} onSelect={() => handleSelect(source)}>
-                      <Check className={cn("mr-2 h-4 w-4", currentSource === source.url ? "opacity-100" : "opacity-0")} />
-                      {source.name}
-                    </CommandItem>
-                  ))}
+                <CommandGroup key={category} heading={label}>
+                  {sources.map((source: RssSource) => {
+                    const sourceName = getSourceName(source, locale)
+                    return (
+                      <CommandItem key={source.url} value={sourceName} onSelect={() => handleSelect(source)}>
+                        <Check className={cn("mr-2 h-4 w-4", currentSource === source.url ? "opacity-100" : "opacity-0")} />
+                        {sourceName}
+                      </CommandItem>
+                    )
+                  })}
                 </CommandGroup>
               );
             })}

--- a/src/components/source-switcher.tsx
+++ b/src/components/source-switcher.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { useState } from "react"
-import { getSourceName, getSourcesByCategory, findSourceByUrl } from "@/config/rss-config"
+import { defaultSource, getSourceName, getSourcesByCategory, findSourceByUrl } from "@/config/rss-config"
 import { useI18n } from "@/i18n"
 
 type RssSource = {
@@ -20,9 +20,11 @@ export function SourceSwitcher() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const currentSource = searchParams.get("source")
+  const selectedSourceUrl = currentSource || defaultSource.url
   const { locale, t } = useI18n()
 
   const [open, setOpen] = useState(false)
+  const [activeCategory, setActiveCategory] = useState("all")
 
   const handleSelect = (source: RssSource) => {
     const params = new URLSearchParams(searchParams)
@@ -36,42 +38,81 @@ export function SourceSwitcher() {
 
   // 按类别分组源
   const groupedSources = getSourcesByCategory(locale)
+  const categoryEntries = Object.entries(groupedSources) as Array<[
+    string,
+    {
+      label: string
+      sources: RssSource[]
+    },
+  ]>
+  const visibleCategoryEntries =
+    activeCategory === "all"
+      ? categoryEntries
+      : categoryEntries.filter(([category]) => category === activeCategory)
 
   // 查找当前源名称
-  const currentSourceData = currentSource ? findSourceByUrl(currentSource) : undefined
+  const currentSourceData = findSourceByUrl(selectedSourceUrl)
   const currentSourceName = currentSourceData ? getSourceName(currentSourceData, locale) : t("sourceSwitcher.select")
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button variant="outline" role="combobox" aria-expanded={open} className="w-full md:w-[300px] justify-between">
-          {currentSourceName}
+        <Button variant="outline" role="combobox" aria-expanded={open} className="w-full md:w-[340px] justify-between">
+          <span className="truncate">{currentSourceName}</span>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
       <PopoverContent 
-        className="w-full md:w-[300px] p-0"
+        className="w-[min(420px,calc(100vw-2rem))] p-0"
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <Command>
           <CommandInput placeholder={t("sourceSwitcher.search")} autoFocus={false} />
-          <CommandList>
+          <div className="border-b px-3 py-2 text-xs text-muted-foreground">
+            {t("sourceSwitcher.current")}: <span className="font-medium text-foreground">{currentSourceName}</span>
+          </div>
+          <div className="border-b px-2 py-2">
+            <div className="flex max-h-24 flex-wrap gap-1 overflow-y-auto pb-1 md:max-h-none md:flex-nowrap md:overflow-x-auto md:overflow-y-hidden">
+              <Button
+                type="button"
+                variant={activeCategory === "all" ? "secondary" : "ghost"}
+                size="sm"
+                className="h-7 shrink-0 px-2 text-xs"
+                onClick={() => setActiveCategory("all")}
+              >
+                {t("sourceSwitcher.all")}
+              </Button>
+              {categoryEntries.map(([category, group]) => (
+                <Button
+                  key={category}
+                  type="button"
+                  variant={activeCategory === category ? "secondary" : "ghost"}
+                  size="sm"
+                  className="h-7 shrink-0 px-2 text-xs"
+                  onClick={() => setActiveCategory(category)}
+                >
+                  {group.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+          <CommandList className="max-h-[40vh] md:max-h-[360px]">
             <CommandEmpty>{t("sourceSwitcher.empty")}</CommandEmpty>
-            {Object.entries(groupedSources).map(([category, group]) => {
-              const { label, sources } = group as { label: string; sources: RssSource[] };
+            {visibleCategoryEntries.map(([category, group]) => {
+              const { label, sources } = group
               return (
-                <CommandGroup key={category} heading={label}>
+                <CommandGroup key={category} heading={activeCategory === "all" ? label : undefined}>
                   {sources.map((source: RssSource) => {
                     const sourceName = getSourceName(source, locale)
                     return (
-                      <CommandItem key={source.url} value={sourceName} onSelect={() => handleSelect(source)}>
-                        <Check className={cn("mr-2 h-4 w-4", currentSource === source.url ? "opacity-100" : "opacity-0")} />
-                        {sourceName}
+                      <CommandItem key={source.url} value={`${sourceName} ${label}`} onSelect={() => handleSelect(source)}>
+                        <Check className={cn("mr-2 h-4 w-4", selectedSourceUrl === source.url ? "opacity-100" : "opacity-0")} />
+                        <span className="truncate">{sourceName}</span>
                       </CommandItem>
                     )
                   })}
                 </CommandGroup>
-              );
+              )
             })}
           </CommandList>
         </Command>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -2,14 +2,18 @@
 
 import { Moon, Sun } from "lucide-react"
 import { useTheme } from "next-themes"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { useI18n } from "@/i18n"
 
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme()
+  const { t } = useI18n()
   const [mounted, setMounted] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const closeFromPointerRef = useRef(false)
 
   // 确保组件只在客户端渲染后才显示，避免服务器/客户端不匹配
   useEffect(() => {
@@ -23,23 +27,49 @@ export function ThemeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon" className="relative">
+        <Button ref={triggerRef} variant="outline" size="icon" className="relative">
           <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          <span className="sr-only">切换主题</span>
+          <span className="sr-only">{t("theme.toggle")}</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => setTheme("light")}>
-          亮色
+      <DropdownMenuContent
+        align="end"
+        onCloseAutoFocus={(event) => {
+          if (!closeFromPointerRef.current) {
+            return
+          }
+
+          event.preventDefault()
+          triggerRef.current?.blur()
+          closeFromPointerRef.current = false
+        }}
+      >
+        <DropdownMenuItem
+          onPointerDown={() => {
+            closeFromPointerRef.current = true
+          }}
+          onClick={() => setTheme("light")}
+        >
+          {t("theme.light")}
           {theme === "light" && " ✓"}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("dark")}>
-          暗色
+        <DropdownMenuItem
+          onPointerDown={() => {
+            closeFromPointerRef.current = true
+          }}
+          onClick={() => setTheme("dark")}
+        >
+          {t("theme.dark")}
           {theme === "dark" && " ✓"}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("system")}>
-          系统
+        <DropdownMenuItem
+          onPointerDown={() => {
+            closeFromPointerRef.current = true
+          }}
+          onClick={() => setTheme("system")}
+        >
+          {t("theme.system")}
           {theme === "system" && " ✓"}
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/config/i18n-config.js
+++ b/src/config/i18n-config.js
@@ -1,0 +1,60 @@
+export const defaultLocale = "zh";
+
+export const locales = {
+  zh: {
+    label: "中文",
+    htmlLang: "zh-CN",
+    dateLocale: "zh-CN",
+    summaryLanguage: "Chinese",
+  },
+  en: {
+    label: "English",
+    htmlLang: "en",
+    dateLocale: "en-US",
+    summaryLanguage: "English",
+  },
+};
+
+export const supportedLocales = Object.keys(locales);
+
+export function isSupportedLocale(locale) {
+  return typeof locale === "string" && Object.prototype.hasOwnProperty.call(locales, locale);
+}
+
+export function resolveLocale(locale) {
+  if (!locale) {
+    return null;
+  }
+
+  if (isSupportedLocale(locale)) {
+    return locale;
+  }
+
+  const languageCode = locale.toLowerCase().split(/[-_]/)[0];
+  return isSupportedLocale(languageCode) ? languageCode : null;
+}
+
+export function getLocaleMeta(locale) {
+  return locales[locale] || locales[defaultLocale];
+}
+
+export function getLocalizedValue(values, locale, fallbackLocale = defaultLocale) {
+  if (!values || typeof values !== "object") {
+    return "";
+  }
+
+  return values[locale] || values[fallbackLocale] || values[Object.keys(values)[0]] || "";
+}
+
+export function parseLocaleList(value, fallbackLocales = supportedLocales) {
+  if (!value) {
+    return fallbackLocales;
+  }
+
+  const parsedLocales = value
+    .split(",")
+    .map((locale) => resolveLocale(locale.trim()))
+    .filter(Boolean);
+
+  return [...new Set(parsedLocales)].length > 0 ? [...new Set(parsedLocales)] : fallbackLocales;
+}

--- a/src/config/rss-config.js
+++ b/src/config/rss-config.js
@@ -1,159 +1,315 @@
-// RSS源接口
-// name: 信息源名称
-// url: RSS URL地址
-// category: 分类名称
+import { defaultLocale, getLocalizedValue } from "./i18n-config.js";
 
-/**
- * @typedef {object} RssSource
- * @property {string} name - 信息源名称
- * @property {string} url - RSS URL地址
- * @property {string} category - 分类名称
- */
+// RSS source schema:
+// id: stable source id
+// name: localized source names
+// url: RSS URL
+// category: stable category id
 
-// 默认配置
+export const categories = {
+  techNews: {
+    name: {
+      zh: "科技资讯",
+      en: "Tech News",
+    },
+  },
+  personalBlogs: {
+    name: {
+      zh: "个人博客",
+      en: "Personal Blogs",
+    },
+  },
+  companyBlogs: {
+    name: {
+      zh: "企业博客",
+      en: "Company Blogs",
+    },
+  },
+  openSource: {
+    name: {
+      zh: "开源项目",
+      en: "Open Source",
+    },
+  },
+  research: {
+    name: {
+      zh: "科研资讯",
+      en: "Research",
+    },
+  },
+  forums: {
+    name: {
+      zh: "论坛",
+      en: "Forums",
+    },
+  },
+  anime: {
+    name: {
+      zh: "番剧资讯",
+      en: "Anime",
+    },
+  },
+  sports: {
+    name: {
+      zh: "体育资讯",
+      en: "Sports",
+    },
+  },
+  podcasts: {
+    name: {
+      zh: "播客",
+      en: "Podcasts",
+    },
+  },
+};
+
 export const config = {
   sources: [
     {
-      name: "Hacker News 近期最佳",
+      id: "hacker-news-best",
+      name: {
+        zh: "Hacker News 近期最佳",
+        en: "Hacker News Best",
+      },
       url: "https://hnrss.org/best",
-      category: "科技资讯",
+      category: "techNews",
     },
     {
-      name: "Hacker News 历史每日前十",
+      id: "hacker-news-daily-top-10",
+      name: {
+        zh: "Hacker News 历史每日前十",
+        en: "Hacker News Daily Top 10",
+      },
       url: "https://rsshub.rssforever.com/github/issue/headllines/hackernews-daily",
-      category: "科技资讯",
+      category: "techNews",
     },
     {
-      name: "OpenAI News",
+      id: "openai-news",
+      name: {
+        zh: "OpenAI News",
+        en: "OpenAI News",
+      },
       url: "https://openai.com/news/rss.xml",
-      category: "科技资讯",
+      category: "techNews",
     },
     {
-      name: "Andrej Karpathy",
+      id: "andrej-karpathy",
+      name: {
+        zh: "Andrej Karpathy",
+        en: "Andrej Karpathy",
+      },
       url: "https://karpathy.bearblog.dev/feed/",
-      category: "个人博客",
+      category: "personalBlogs",
     },
     {
-      name: "Simon Willison's Weblog",
+      id: "simon-willison",
+      name: {
+        zh: "Simon Willison's Weblog",
+        en: "Simon Willison's Weblog",
+      },
       url: "https://simonwillison.net/atom/everything/",
-      category: "个人博客",
+      category: "personalBlogs",
     },
     {
-      name: "Mario Zechner's Blog",
+      id: "mario-zechner",
+      name: {
+        zh: "Mario Zechner's Blog",
+        en: "Mario Zechner's Blog",
+      },
       url: "https://mariozechner.at/rss.xml",
-      category: "个人博客",
+      category: "personalBlogs",
     },
     {
-      name: "阮一峰的个人网站",
+      id: "ruanyifeng",
+      name: {
+        zh: "阮一峰的个人网站",
+        en: "Ruanyifeng's Blog",
+      },
       url: "http://www.ruanyifeng.com/blog/atom.xml",
-      category: "个人博客",
+      category: "personalBlogs",
     },
     {
-      name: "Google 产品和技术新闻",
+      id: "google-product-news",
+      name: {
+        zh: "Google 产品和技术新闻",
+        en: "Google Product and Technology News",
+      },
       url: "https://blog.google/rss/",
-      category: "企业博客",
+      category: "companyBlogs",
     },
     {
-      name: "Github 博客",
+      id: "github-blog",
+      name: {
+        zh: "Github 博客",
+        en: "GitHub Blog",
+      },
       url: "https://github.blog/feed/",
-      category: "企业博客",
+      category: "companyBlogs",
     },
     {
-      name: "Hugging Face 博客",
+      id: "hugging-face-blog",
+      name: {
+        zh: "Hugging Face 博客",
+        en: "Hugging Face Blog",
+      },
       url: "https://rsshub.rssforever.com/huggingface/blog",
-      category: "企业博客",
+      category: "companyBlogs",
     },
     {
-      name: "Google 开发者博客",
+      id: "google-developers-blog",
+      name: {
+        zh: "Google 开发者博客",
+        en: "Google Developers Blog",
+      },
       url: "https://rsshub.rssforever.com/google/developers/en",
-      category: "企业博客",
+      category: "companyBlogs",
     },
     {
-      name: "Google 研究博客",
+      id: "google-research-blog",
+      name: {
+        zh: "Google 研究博客",
+        en: "Google Research Blog",
+      },
       url: "https://rsshub.rssforever.com/google/research",
-      category: "企业博客",
+      category: "companyBlogs",
     },
     {
-      name: "Google DeepMind",
+      id: "google-deepmind",
+      name: {
+        zh: "Google DeepMind",
+        en: "Google DeepMind",
+      },
       url: "https://deepmind.google/blog/rss.xml",
-      category: "企业博客",
+      category: "companyBlogs",
     },
     {
-      name: "Microsoft Research",
+      id: "microsoft-research",
+      name: {
+        zh: "Microsoft Research",
+        en: "Microsoft Research",
+      },
       url: "https://www.microsoft.com/en-us/research/feed/",
-      category: "企业博客",
+      category: "companyBlogs",
     },
     {
-      name: "Github 今日热门",
+      id: "github-trending-daily",
+      name: {
+        zh: "Github 今日热门",
+        en: "GitHub Trending Today",
+      },
       url: "https://rsshub.rssforever.com/github/trending/daily/any",
-      category: "开源项目",
+      category: "openSource",
     },
     {
-      name: "Github 近一周热门",
+      id: "github-trending-weekly",
+      name: {
+        zh: "Github 近一周热门",
+        en: "GitHub Trending This Week",
+      },
       url: "https://rsshub.rssforever.com/github/trending/weekly/any",
-      category: "开源项目",
+      category: "openSource",
     },
     {
-      name: "Hugging Face 每日论文",
+      id: "hugging-face-daily-papers",
+      name: {
+        zh: "Hugging Face 每日论文",
+        en: "Hugging Face Daily Papers",
+      },
       url: "https://rsshub.rssforever.com/huggingface/daily-papers",
-      category: "科研资讯",
+      category: "research",
     },
     {
-      name: "LINUX DO 今日热门",
+      id: "linux-do-daily-top",
+      name: {
+        zh: "LINUX DO 今日热门",
+        en: "LINUX DO Daily Top",
+      },
       url: "https://r4l.deno.dev/https://linux.do/top.rss?period=daily",
-      category: "论坛",
+      category: "forums",
     },
     {
-      name: "LINUX DO 近一周热门",
+      id: "linux-do-weekly-top",
+      name: {
+        zh: "LINUX DO 近一周热门",
+        en: "LINUX DO Weekly Top",
+      },
       url: "https://r4l.deno.dev/https://linux.do/top.rss?period=weekly",
-      category: "论坛",
+      category: "forums",
     },
     {
-      name: "LINUX DO 近一月热门",
+      id: "linux-do-monthly-top",
+      name: {
+        zh: "LINUX DO 近一月热门",
+        en: "LINUX DO Monthly Top",
+      },
       url: "https://r4l.deno.dev/https://linux.do/top.rss?period=monthly",
-      category: "论坛",
+      category: "forums",
     },
     {
-      name: "V2EX 今日热门",
+      id: "v2ex-hot",
+      name: {
+        zh: "V2EX 今日热门",
+        en: "V2EX Hot Today",
+      },
       url: "https://rsshub.rssforever.com/v2ex/topics/hot",
-      category: "论坛",
+      category: "forums",
     },
     {
-      name: "Bangumi 近一月热门",
+      id: "bangumi-monthly-popular",
+      name: {
+        zh: "Bangumi 近一月热门",
+        en: "Bangumi Monthly Popular",
+      },
       url: "https://rsshub.rssforever.com/bangumi.tv/anime/followrank",
-      category: "番剧资讯",
+      category: "anime",
     },
     {
-      name: "F1 News",
+      id: "f1-news",
+      name: {
+        zh: "F1 News",
+        en: "F1 News",
+      },
       url: "https://www.formula1.com/content/fom-website/en/latest/all.xml",
-      category: "体育资讯",
+      category: "sports",
     },
     {
-      name: "Lex Fridman Podcast",
+      id: "lex-fridman-podcast",
+      name: {
+        zh: "Lex Fridman Podcast",
+        en: "Lex Fridman Podcast",
+      },
       url: "https://lexfridman.com/feed/podcast/",
-      category: "播客",
+      category: "podcasts",
     },
   ],
   maxItemsPerFeed: 30,
   dataPath: "./public/data",
-}
+};
 
-export const defaultSource = config.sources[0]
+export const defaultSource = config.sources[0];
 
-/**
- * @param {string} url
- * @returns {RssSource | undefined}
- */
 export function findSourceByUrl(url) {
-  return config.sources.find((source) => source.url === url)
+  return config.sources.find((source) => source.url === url);
 }
 
-export function getSourcesByCategory() {
+export function getSourceName(source, locale = defaultLocale) {
+  return getLocalizedValue(source.name, locale);
+}
+
+export function getCategoryName(categoryId, locale = defaultLocale) {
+  return getLocalizedValue(categories[categoryId]?.name, locale) || categoryId;
+}
+
+export function getSourcesByCategory(locale = defaultLocale) {
   return config.sources.reduce((acc, source) => {
     if (!acc[source.category]) {
-      acc[source.category] = []
+      acc[source.category] = {
+        label: getCategoryName(source.category, locale),
+        sources: [],
+      };
     }
-    acc[source.category].push(source)
-    return acc
-  }, {})
+
+    acc[source.category].sources.push(source);
+    return acc;
+  }, {});
 }

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -29,6 +29,8 @@ const translations = {
       select: "选择信息源",
       search: "搜索信息源...",
       empty: "未找到匹配的信息源",
+      all: "全部",
+      current: "当前",
     },
     feed: {
       emptyData: "数据为空，请检查数据源是否出错🫠",
@@ -64,6 +66,8 @@ const translations = {
       select: "Select source",
       search: "Search sources...",
       empty: "No matching source found",
+      all: "All",
+      current: "Current",
     },
     feed: {
       emptyData: "No data found. Please check whether the source is working 🫠",

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1,0 +1,203 @@
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react"
+import {
+  defaultLocale,
+  getLocaleMeta,
+  isSupportedLocale,
+  resolveLocale,
+  supportedLocales,
+} from "@/config/i18n-config"
+
+export type Locale = string
+export const localeOptions = supportedLocales
+
+export const localeLabels = Object.fromEntries(
+  supportedLocales.map((locale: Locale) => [locale, getLocaleMeta(locale).label]),
+)
+
+export const dateLocales = Object.fromEntries(
+  supportedLocales.map((locale: Locale) => [locale, getLocaleMeta(locale).dateLocale]),
+)
+
+const translations = {
+  zh: {
+    app: {
+      github: "GitHub 仓库",
+      tagline: "从多个信息源获取最新内容，由 AI 生成摘要",
+      footer: "Stay hungry. 😋",
+    },
+    sourceSwitcher: {
+      select: "选择信息源",
+      search: "搜索信息源...",
+      empty: "未找到匹配的信息源",
+    },
+    feed: {
+      emptyData: "数据为空，请检查数据源是否出错🫠",
+      fetchError: "数据获取失败，请检查数据源是否出错🫠",
+      sourceFallback: "信息源",
+      updatedAt: "更新于",
+      summary: "AI 摘要",
+      original: "原文内容",
+      summaryGeneratedByAi: "由 AI 生成的摘要：",
+      summaryUnavailable: "无法生成摘要。",
+      noContent: "无内容",
+    },
+    theme: {
+      toggle: "切换主题",
+      light: "亮色",
+      dark: "暗色",
+      system: "系统",
+    },
+    language: {
+      toggle: "切换语言",
+    },
+    scrollToTop: {
+      label: "返回顶部",
+    },
+  },
+  en: {
+    app: {
+      github: "GitHub repository",
+      tagline: "Get the latest updates from multiple sources, summarized by AI",
+      footer: "Stay hungry. 😋",
+    },
+    sourceSwitcher: {
+      select: "Select source",
+      search: "Search sources...",
+      empty: "No matching source found",
+    },
+    feed: {
+      emptyData: "No data found. Please check whether the source is working 🫠",
+      fetchError: "Failed to fetch data. Please check whether the source is working 🫠",
+      sourceFallback: "Source",
+      updatedAt: "Updated at",
+      summary: "AI Summary",
+      original: "Original",
+      summaryGeneratedByAi: "AI-generated summary:",
+      summaryUnavailable: "Unable to generate summary.",
+      noContent: "No content",
+    },
+    theme: {
+      toggle: "Toggle theme",
+      light: "Light",
+      dark: "Dark",
+      system: "System",
+    },
+    language: {
+      toggle: "Switch language",
+    },
+    scrollToTop: {
+      label: "Back to top",
+    },
+  },
+} as const
+
+export type I18nKey = string
+
+function isLocale(value: string | null | undefined): value is Locale {
+  return isSupportedLocale(value)
+}
+
+function getFromTranslations(locale: Locale, key: I18nKey): string {
+  const value = key.split(".").reduce<unknown>((acc, part) => {
+    if (acc && typeof acc === "object" && part in acc) {
+      return (acc as Record<string, unknown>)[part]
+    }
+    return undefined
+  }, translations[locale])
+
+  if (typeof value === "string") {
+    return value
+  }
+
+  const fallbackValue = key.split(".").reduce<unknown>((acc, part) => {
+    if (acc && typeof acc === "object" && part in acc) {
+      return (acc as Record<string, unknown>)[part]
+    }
+    return undefined
+  }, translations[defaultLocale])
+
+  return typeof fallbackValue === "string" ? fallbackValue : key
+}
+
+function readLocaleFromUrl(): Locale | null {
+  return resolveLocale(new URLSearchParams(window.location.search).get("lang"))
+}
+
+function getInitialLocale(): Locale {
+  const urlLocale = readLocaleFromUrl()
+  if (urlLocale) {
+    return urlLocale
+  }
+
+  const storedLocale = window.localStorage.getItem("feedme-locale")
+  if (isLocale(storedLocale)) {
+    return storedLocale
+  }
+
+  const browserLocales = window.navigator.languages?.length ? window.navigator.languages : [window.navigator.language]
+  for (const browserLocale of browserLocales) {
+    const resolvedLocale = resolveLocale(browserLocale)
+    if (resolvedLocale) {
+      return resolvedLocale
+    }
+  }
+
+  return defaultLocale
+}
+
+interface I18nContextValue {
+  locale: Locale
+  setLocale: (locale: Locale) => void
+  t: (key: I18nKey) => string
+}
+
+const I18nContext = createContext<I18nContextValue | null>(null)
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<Locale>(() => getInitialLocale())
+
+  useEffect(() => {
+    document.documentElement.lang = getLocaleMeta(locale).htmlLang
+  }, [locale])
+
+  useEffect(() => {
+    const handlePopState = () => {
+      const urlLocale = readLocaleFromUrl()
+      if (urlLocale) {
+        setLocaleState(urlLocale)
+      }
+    }
+
+    window.addEventListener("popstate", handlePopState)
+    return () => window.removeEventListener("popstate", handlePopState)
+  }, [])
+
+  const setLocale = (nextLocale: Locale) => {
+    setLocaleState(nextLocale)
+    window.localStorage.setItem("feedme-locale", nextLocale)
+
+    const url = new URL(window.location.href)
+    url.searchParams.set("lang", nextLocale)
+    window.history.replaceState({}, "", `${url.pathname}${url.search}${url.hash}`)
+    window.dispatchEvent(new PopStateEvent("popstate"))
+  }
+
+  const value = useMemo<I18nContextValue>(
+    () => ({
+      locale,
+      setLocale,
+      t: (key) => getFromTranslations(locale, key),
+    }),
+    [locale],
+  )
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>
+}
+
+export function useI18n() {
+  const value = useContext(I18nContext)
+  if (!value) {
+    throw new Error("useI18n must be used within I18nProvider")
+  }
+  return value
+}

--- a/src/lib/data-store.ts
+++ b/src/lib/data-store.ts
@@ -86,6 +86,10 @@ export async function mergeFeedItems(
       // 无论如何都更新Map，使用新条目（但保留旧摘要如果有的话）
       const serializedItem: FeedItem = {
         ...item,
+        summaries: {
+          ...item.summaries,
+          ...existingItem?.summaries,
+        },
         summary: existingItem?.summary || item.summary,
       }
       

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,7 @@ export interface FeedItem {
   content?: string
   contentSnippet?: string
   creator?: string
+  summaries?: Record<string, string>
   summary?: string
   enclosure?: {
     url: string


### PR DESCRIPTION
## Summary
- add locale-aware i18n infrastructure for UI text, source names, categories, dates, and AI summaries
- add a right-side language toggle with URL/localStorage locale persistence
- improve the source switcher with current-source display, category filters, wider/truncated labels, and mobile-friendly sizing
- keep the homepage default source visible as Hacker News Best when no source param is set

## Verification
- pnpm build
- git diff --check
- browser checked desktop preview at /?lang=en
- browser checked mobile source switching at 390x844 and 375x667, including Podcasts -> Lex Fridman Podcast