### PR TITLE
Refine dark theme and source scrollbar

### DIFF
--- a/src/components/source-switcher.tsx
+++ b/src/components/source-switcher.tsx
@@ -72,7 +72,7 @@ export function SourceSwitcher() {
             {t("sourceSwitcher.current")}: <span className="font-medium text-foreground">{currentSourceName}</span>
           </div>
           <div className="border-b px-2 py-2">
-            <div className="flex max-h-24 flex-wrap gap-1 overflow-y-auto pb-1 md:max-h-none md:flex-nowrap md:overflow-x-auto md:overflow-y-hidden">
+            <div className="source-category-scroll flex max-h-24 flex-wrap gap-1 overflow-y-auto pb-2 md:max-h-none md:flex-nowrap md:overflow-x-auto md:overflow-y-hidden">
               <Button
                 type="button"
                 variant={activeCategory === "all" ? "secondary" : "ghost"}

--- a/src/components/source-switcher.tsx
+++ b/src/components/source-switcher.tsx
@@ -72,7 +72,7 @@ export function SourceSwitcher() {
             {t("sourceSwitcher.current")}: <span className="font-medium text-foreground">{currentSourceName}</span>
           </div>
           <div className="border-b px-2 py-2">
-            <div className="source-category-scroll flex max-h-24 flex-wrap gap-1 overflow-y-auto pb-2 md:max-h-none md:flex-nowrap md:overflow-x-auto md:overflow-y-hidden">
+            <div className="source-scroll flex max-h-24 flex-wrap gap-1 overflow-y-auto pb-2 md:max-h-none md:flex-nowrap md:overflow-x-auto md:overflow-y-hidden">
               <Button
                 type="button"
                 variant={activeCategory === "all" ? "secondary" : "ghost"}
@@ -96,7 +96,7 @@ export function SourceSwitcher() {
               ))}
             </div>
           </div>
-          <CommandList className="max-h-[40vh] md:max-h-[360px]">
+          <CommandList className="source-scroll max-h-[40vh] pr-1 md:max-h-[360px]">
             <CommandEmpty>{t("sourceSwitcher.empty")}</CommandEmpty>
             {visibleCategoryEntries.map(([category, group]) => {
               const { label, sources } = group

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -33,7 +33,7 @@ const translations = {
       current: "当前",
     },
     feed: {
-      emptyData: "数据为空，请检查数据源是否出错🫠",
+      emptyData: "数据为空，可能是由于该RSS源不稳定🫠",
       fetchError: "数据获取失败，请检查数据源是否出错🫠",
       sourceFallback: "信息源",
       updatedAt: "更新于",
@@ -70,7 +70,7 @@ const translations = {
       current: "Current",
     },
     feed: {
-      emptyData: "No data found. Please check whether the source is working 🫠",
+      emptyData: "No data found. This RSS source may be unstable 🫠",
       fetchError: "Failed to fetch data. Please check whether the source is working 🫠",
       sourceFallback: "Source",
       updatedAt: "Updated at",

--- a/src/index.css
+++ b/src/index.css
@@ -47,33 +47,33 @@ body {
   }
 
   .dark {
-    --background: 220 18% 12%;
-    --foreground: 210 40% 92%;
+    --background: 225 16% 9%;
+    --foreground: 215 28% 90%;
 
-    --card: 220 16% 16%;
-    --card-foreground: 210 40% 92%;
+    --card: 224 14% 14%;
+    --card-foreground: 215 28% 91%;
 
-    --popover: 220 16% 18%;
-    --popover-foreground: 210 40% 92%;
+    --popover: 224 14% 15.5%;
+    --popover-foreground: 215 28% 91%;
 
-    --primary: 213 72% 65%;
-    --primary-foreground: 214 100% 97%;
+    --primary: 210 78% 68%;
+    --primary-foreground: 222 47% 10%;
 
-    --secondary: 220 14% 22%;
-    --secondary-foreground: 210 30% 92%;
+    --secondary: 220 12% 18%;
+    --secondary-foreground: 215 24% 88%;
 
-    --muted: 220 15% 20%;
-    --muted-foreground: 215 20% 72%;
+    --muted: 220 12% 18%;
+    --muted-foreground: 216 14% 68%;
 
-    --accent: 205 48% 45%;
-    --accent-foreground: 210 100% 96%;
+    --accent: 178 34% 22%;
+    --accent-foreground: 180 38% 88%;
 
-    --destructive: 0 62% 55%;
+    --destructive: 0 68% 62%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 220 16% 24%;
-    --input: 220 16% 24%;
-    --ring: 213 72% 65%;
+    --border: 222 13% 22%;
+    --input: 222 13% 24%;
+    --ring: 210 78% 68%;
   }
 }
 
@@ -91,7 +91,41 @@ body {
     @apply border border-border bg-card shadow-sm hover:shadow-md transition-all duration-300 relative;
   }
 
+  .source-category-scroll {
+    scrollbar-color: hsl(var(--muted-foreground) / 0.34) transparent;
+    scrollbar-width: thin;
+  }
+
+  .source-category-scroll::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+  }
+
+  .source-category-scroll::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .source-category-scroll::-webkit-scrollbar-thumb {
+    background: hsl(var(--muted-foreground) / 0.34);
+    border-radius: 999px;
+  }
+
+  .source-category-scroll::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--muted-foreground) / 0.52);
+  }
+
   .dark .feed-card {
-    @apply bg-card border-border shadow-md hover:shadow-lg;
+    @apply bg-card border-border;
+    box-shadow:
+      0 1px 0 hsl(0 0% 100% / 0.03),
+      0 10px 28px hsl(225 35% 4% / 0.28);
+  }
+
+  .dark .feed-card:hover {
+    border-color: hsl(var(--primary) / 0.34);
+    box-shadow:
+      0 1px 0 hsl(0 0% 100% / 0.045),
+      0 18px 48px hsl(225 40% 3% / 0.48),
+      0 0 0 1px hsl(var(--primary) / 0.12);
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -91,26 +91,27 @@ body {
     @apply border border-border bg-card shadow-sm hover:shadow-md transition-all duration-300 relative;
   }
 
-  .source-category-scroll {
+  .source-scroll {
+    scrollbar-gutter: stable;
     scrollbar-color: hsl(var(--muted-foreground) / 0.34) transparent;
     scrollbar-width: thin;
   }
 
-  .source-category-scroll::-webkit-scrollbar {
+  .source-scroll::-webkit-scrollbar {
     width: 4px;
     height: 4px;
   }
 
-  .source-category-scroll::-webkit-scrollbar-track {
+  .source-scroll::-webkit-scrollbar-track {
     background: transparent;
   }
 
-  .source-category-scroll::-webkit-scrollbar-thumb {
+  .source-scroll::-webkit-scrollbar-thumb {
     background: hsl(var(--muted-foreground) / 0.34);
     border-radius: 999px;
   }
 
-  .source-category-scroll::-webkit-scrollbar-thumb:hover {
+  .source-scroll::-webkit-scrollbar-thumb:hover {
     background: hsl(var(--muted-foreground) / 0.52);
   }
 


### PR DESCRIPTION
## Summary
- refine dark mode tokens for a calmer reading surface with clearer background/card/popover layering
- restore visible dark-mode card elevation and hover emphasis with darker shadows and subtle border highlight
- replace the source category bar default scrollbar with a thin theme-aware scrollbar and extra bottom spacing

## Verification
- pnpm build
- git diff --check origin/main..HEAD
- browser checked dark mode preview and source category scrollbar at localhost:3000
