### PR TITLE
Update Linux.do RSS sources and company blog order

### DIFF
--- a/src/config/rss-config.js
+++ b/src/config/rss-config.js
@@ -138,24 +138,6 @@ export const config = {
       category: "companyBlogs",
     },
     {
-      id: "github-blog",
-      name: {
-        zh: "Github 博客",
-        en: "GitHub Blog",
-      },
-      url: "https://github.blog/feed/",
-      category: "companyBlogs",
-    },
-    {
-      id: "hugging-face-blog",
-      name: {
-        zh: "Hugging Face 博客",
-        en: "Hugging Face Blog",
-      },
-      url: "https://rsshub.rssforever.com/huggingface/blog",
-      category: "companyBlogs",
-    },
-    {
       id: "google-developers-blog",
       name: {
         zh: "Google 开发者博客",
@@ -180,6 +162,24 @@ export const config = {
         en: "Google DeepMind",
       },
       url: "https://deepmind.google/blog/rss.xml",
+      category: "companyBlogs",
+    },
+    {
+      id: "github-blog",
+      name: {
+        zh: "Github 博客",
+        en: "GitHub Blog",
+      },
+      url: "https://github.blog/feed/",
+      category: "companyBlogs",
+    },
+    {
+      id: "hugging-face-blog",
+      name: {
+        zh: "Hugging Face 博客",
+        en: "Hugging Face Blog",
+      },
+      url: "https://rsshub.rssforever.com/huggingface/blog",
       category: "companyBlogs",
     },
     {
@@ -224,7 +224,7 @@ export const config = {
         zh: "LINUX DO 今日热门",
         en: "LINUX DO Daily Top",
       },
-      url: "https://r4l.deno.dev/https://linux.do/top.rss?period=daily",
+      url: "https://linux.do/top.rss?period=daily",
       category: "forums",
     },
     {
@@ -233,7 +233,7 @@ export const config = {
         zh: "LINUX DO 近一周热门",
         en: "LINUX DO Weekly Top",
       },
-      url: "https://r4l.deno.dev/https://linux.do/top.rss?period=weekly",
+      url: "https://linux.do/top.rss?period=weekly",
       category: "forums",
     },
     {
@@ -242,7 +242,7 @@ export const config = {
         zh: "LINUX DO 近一月热门",
         en: "LINUX DO Monthly Top",
       },
-      url: "https://r4l.deno.dev/https://linux.do/top.rss?period=monthly",
+      url: "https://linux.do/top.rss?period=monthly",
       category: "forums",
     },
     {


### PR DESCRIPTION
## Summary
- group Google company blog sources together in the source switcher order
- replace the Linux.do proxied RSS URLs with direct Linux.do RSS URLs
- use `https://linux.do/top.rss?period=weekly` for weekly because `https://linux.do/top?period=weekly` returns 403 and is not parseable as RSS

## Verification
- parsed all three Linux.do RSS URLs locally with `rss-parser`; daily/weekly/monthly each returned 30 items
- verified company blog order in the local browser source switcher
- pnpm build
- git diff --check
