### PR TITLE
Improve feed update logging

### DIFF
--- a/scripts/update-feeds.js
+++ b/scripts/update-feeds.js
@@ -164,6 +164,47 @@ function normalizeSummaries(item = {}) {
   return summaries;
 }
 
+function createLocaleCounter() {
+  return Object.fromEntries(SUMMARY_LOCALES.map((locale) => [locale, 0]));
+}
+
+function formatLocaleCounts(counter) {
+  return SUMMARY_LOCALES.map((locale) => `${locale}:${counter[locale] || 0}`).join(", ");
+}
+
+function createSummaryPlan(mergedItems, newItemLinks) {
+  const plan = {
+    retainedNewItems: 0,
+    retainedExistingItems: 0,
+    generate: createLocaleCounter(),
+    reuse: createLocaleCounter(),
+    skippedMissingExisting: createLocaleCounter(),
+  };
+
+  for (const item of mergedItems) {
+    const summaries = normalizeSummaries(item);
+    const isRetainedNewItem = Boolean(item.link && newItemLinks.has(item.link));
+
+    if (isRetainedNewItem) {
+      plan.retainedNewItems += 1;
+    } else {
+      plan.retainedExistingItems += 1;
+    }
+
+    for (const locale of SUMMARY_LOCALES) {
+      if (summaries[locale]) {
+        plan.reuse[locale] += 1;
+      } else if (isRetainedNewItem) {
+        plan.generate[locale] += 1;
+      } else {
+        plan.skippedMissingExisting[locale] += 1;
+      }
+    }
+  }
+
+  return plan;
+}
+
 function buildSummaryPrompt(title, content, locale) {
   const { summaryLanguage } = getLocaleMeta(locale);
 
@@ -338,7 +379,19 @@ async function updateFeed(sourceUrl) {
       config.maxItemsPerFeed,
     );
 
-    console.log(`发现 ${newItemsForSummary.length} 条新条目，来自 ${sourceUrl}`);
+    const newItemLinks = new Set(newItemsForSummary.map((item) => item.link).filter(Boolean));
+    const summaryPlan = createSummaryPlan(mergedItems, newItemLinks);
+
+    console.log(
+      `源统计 ${sourceUrl}: RSS返回 ${newFeed.items.length} 条，保留 ${mergedItems.length}/${config.maxItemsPerFeed} 条；` +
+      `feed新链接 ${newItemsForSummary.length} 条，保留列表新条目 ${summaryPlan.retainedNewItems} 条，` +
+      `复用已有条目 ${summaryPlan.retainedExistingItems} 条`,
+    );
+    console.log(
+      `摘要计划 ${sourceUrl}: 将生成 ${formatLocaleCounts(summaryPlan.generate)}；` +
+      `已有/复用 ${formatLocaleCounts(summaryPlan.reuse)}；` +
+      `旧条目缺失但跳过 ${formatLocaleCounts(summaryPlan.skippedMissingExisting)}`,
+    );
 
     // 为新条目生成摘要
     const itemsWithSummaries = await Promise.all(
@@ -346,7 +399,7 @@ async function updateFeed(sourceUrl) {
         const summaries = normalizeSummaries(item);
 
         // 如果是新条目且需要生成摘要
-        if (newItemsForSummary.some((newItem) => newItem.link === item.link)) {
+        if (item.link && newItemLinks.has(item.link)) {
           try {
             // 确保使用任何可用的内容源 - content, item 本身的 summary 字段, 或 contentSnippet
             const contentForSummary = item.content || item.contentSnippet || "";

--- a/src/config/rss-config.js
+++ b/src/config/rss-config.js
@@ -84,15 +84,6 @@ export const config = {
       category: "techNews",
     },
     {
-      id: "openai-news",
-      name: {
-        zh: "OpenAI News",
-        en: "OpenAI News",
-      },
-      url: "https://openai.com/news/rss.xml",
-      category: "techNews",
-    },
-    {
       id: "andrej-karpathy",
       name: {
         zh: "Andrej Karpathy",
@@ -127,6 +118,15 @@ export const config = {
       },
       url: "http://www.ruanyifeng.com/blog/atom.xml",
       category: "personalBlogs",
+    },
+    {
+      id: "openai-news",
+      name: {
+        zh: "OpenAI News",
+        en: "OpenAI News",
+      },
+      url: "https://openai.com/news/rss.xml",
+      category: "companyBlogs",
     },
     {
       id: "google-product-news",


### PR DESCRIPTION
## Summary
- replace the broad "new items" log with source stats that separate RSS item count, retained item count, feed-new links, retained-new items, and reused items
- add locale-level summary plan logs for generated, reused, and skipped-missing summaries
- move OpenAI News from Tech News to Company Blogs while preserving the source category order

## Verification
- node --check scripts/update-feeds.js
- git diff --check
- pnpm build
