### PR TITLE
Unify dark mode accent color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -65,8 +65,8 @@ body {
     --muted: 220 12% 18%;
     --muted-foreground: 216 14% 68%;
 
-    --accent: 178 34% 22%;
-    --accent-foreground: 180 38% 88%;
+    --accent: 214 42% 24%;
+    --accent-foreground: 213 54% 91%;
 
     --destructive: 0 68% 62%;
     --destructive-foreground: 0 0% 98%;


### PR DESCRIPTION
## Summary
- align dark mode accent color with the existing blue primary palette
- make source menu hover/selected states visually consistent with feed content accents

## Tests
- pnpm build
- git diff --check
- browser check: dark source menu selected background is blue-toned