### PR TITLE
Improve source switcher scrolling and focus handling

### DIFF
--- a/src/components/language-toggle.tsx
+++ b/src/components/language-toggle.tsx
@@ -21,6 +21,9 @@ export function LanguageToggle() {
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"
+        onPointerDownOutside={() => {
+          closeFromPointerRef.current = true
+        }}
         onCloseAutoFocus={(event) => {
           if (!closeFromPointerRef.current) {
             return

--- a/src/components/source-switcher.tsx
+++ b/src/components/source-switcher.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import { useState } from "react"
+import { useCallback, useLayoutEffect, useRef, useState } from "react"
 import { defaultSource, findSourceByUrl, getSourceName, getSourcesByCategory, type RssSource } from "@/config/rss-config"
 import { useI18n } from "@/i18n"
 
@@ -19,6 +19,70 @@ export function SourceSwitcher() {
 
   const [open, setOpen] = useState(false)
   const [activeCategory, setActiveCategory] = useState("all")
+  const categoryScrollRef = useRef<HTMLDivElement>(null)
+  const categoryScrollLeftRef = useRef(0)
+  const categoryScrollbarDragRef = useRef<{
+    pointerId: number
+    thumbOffsetX: number
+  } | null>(null)
+  const [isCategoryScrollbarDragging, setIsCategoryScrollbarDragging] = useState(false)
+  const [isCategoryScrollbarVisible, setIsCategoryScrollbarVisible] = useState(false)
+  const [categoryScroll, setCategoryScroll] = useState({
+    clientWidth: 0,
+    maxScroll: 0,
+    scrollLeft: 0,
+    scrollWidth: 0,
+  })
+
+  const syncCategoryScroll = useCallback(() => {
+    const scrollElement = categoryScrollRef.current
+    if (!scrollElement) {
+      return
+    }
+
+    const nextScroll = {
+      clientWidth: scrollElement.clientWidth,
+      maxScroll: Math.max(0, scrollElement.scrollWidth - scrollElement.clientWidth),
+      scrollLeft: scrollElement.scrollLeft,
+      scrollWidth: scrollElement.scrollWidth,
+    }
+
+    categoryScrollLeftRef.current = nextScroll.scrollLeft
+
+    setCategoryScroll((currentScroll) =>
+      currentScroll.clientWidth === nextScroll.clientWidth &&
+      currentScroll.maxScroll === nextScroll.maxScroll &&
+      currentScroll.scrollLeft === nextScroll.scrollLeft &&
+      currentScroll.scrollWidth === nextScroll.scrollWidth
+        ? currentScroll
+        : nextScroll,
+    )
+  }, [])
+
+  const setCategoryScrollElement = useCallback(
+    (scrollElement: HTMLDivElement | null) => {
+      categoryScrollRef.current = scrollElement
+
+      if (scrollElement) {
+        scrollElement.scrollLeft = categoryScrollLeftRef.current
+        syncCategoryScroll()
+        requestAnimationFrame(syncCategoryScroll)
+      }
+    },
+    [syncCategoryScroll],
+  )
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        setIsCategoryScrollbarDragging(false)
+        setIsCategoryScrollbarVisible(false)
+      }
+
+      setOpen(nextOpen)
+    },
+    [],
+  )
 
   const handleSelect = (source: RssSource) => {
     const params = new URLSearchParams(searchParams)
@@ -27,7 +91,108 @@ export function SourceSwitcher() {
     // 使用当前页面路径，保留 basePath
     const currentPath = window.location.pathname
     router.push(`${currentPath}?${params.toString()}`)
-    setOpen(false)
+    handleOpenChange(false)
+  }
+
+  const scrollCategoryToPointer = useCallback(
+    (trackElement: HTMLDivElement, clientX: number, thumbOffsetX: number) => {
+      const scrollElement = categoryScrollRef.current
+      if (!scrollElement || categoryScroll.maxScroll <= 0) {
+        return
+      }
+
+      const trackRect = trackElement.getBoundingClientRect()
+      const thumbElement = trackElement.querySelector<HTMLElement>(".source-category-scrollbar-thumb")
+      const thumbWidth = thumbElement?.getBoundingClientRect().width || trackRect.width
+      const maxThumbLeft = Math.max(1, trackRect.width - thumbWidth)
+      const thumbLeft = Math.min(
+        maxThumbLeft,
+        Math.max(0, clientX - trackRect.left - thumbOffsetX),
+      )
+      const progress = thumbLeft / maxThumbLeft
+      scrollElement.scrollLeft = progress * categoryScroll.maxScroll
+      syncCategoryScroll()
+    },
+    [categoryScroll.maxScroll, syncCategoryScroll],
+  )
+
+  const handleCategoryScrollbarPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    const scrollElement = categoryScrollRef.current
+    if (!scrollElement || categoryScroll.maxScroll <= 0) {
+      return
+    }
+
+    event.currentTarget.setPointerCapture(event.pointerId)
+    setIsCategoryScrollbarDragging(true)
+
+    const thumbElement = event.currentTarget.querySelector<HTMLElement>(".source-category-scrollbar-thumb")
+    const thumbRect = thumbElement?.getBoundingClientRect()
+    const isThumbTarget = event.target instanceof Element && event.target.closest(".source-category-scrollbar-thumb")
+    const thumbOffsetX =
+      isThumbTarget && thumbRect
+        ? event.clientX - thumbRect.left
+        : (thumbRect?.width || 0) / 2
+
+    categoryScrollbarDragRef.current = {
+      pointerId: event.pointerId,
+      thumbOffsetX,
+    }
+    scrollCategoryToPointer(event.currentTarget, event.clientX, thumbOffsetX)
+  }
+
+  const handleCategoryScrollbarPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const dragState = categoryScrollbarDragRef.current
+    if (!dragState || dragState.pointerId !== event.pointerId || !event.currentTarget.hasPointerCapture(event.pointerId)) {
+      return
+    }
+
+    scrollCategoryToPointer(event.currentTarget, event.clientX, dragState.thumbOffsetX)
+  }
+
+  const finishCategoryScrollbarPointer = (event: React.PointerEvent<HTMLDivElement>) => {
+    categoryScrollbarDragRef.current = null
+    setIsCategoryScrollbarDragging(false)
+    const regionElement = event.currentTarget.closest<HTMLElement>(".source-category-region")
+    const regionRect = regionElement?.getBoundingClientRect()
+    const pointerIsInRegion =
+      !!regionRect &&
+      event.clientX >= regionRect.left &&
+      event.clientX <= regionRect.right &&
+      event.clientY >= regionRect.top &&
+      event.clientY <= regionRect.bottom
+
+    setIsCategoryScrollbarVisible(pointerIsInRegion)
+    event.currentTarget.blur()
+  }
+
+  const showCategoryScrollbar = useCallback(() => {
+    setIsCategoryScrollbarVisible(true)
+  }, [])
+
+  const hideCategoryScrollbar = useCallback(() => {
+    if (!isCategoryScrollbarDragging) {
+      setIsCategoryScrollbarVisible(false)
+    }
+  }, [isCategoryScrollbarDragging])
+
+  const handleCategoryScrollbarKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const scrollElement = categoryScrollRef.current
+    if (!scrollElement || categoryScroll.maxScroll <= 0) {
+      return
+    }
+
+    const step = 80
+    if (event.key === "ArrowLeft") {
+      event.preventDefault()
+      scrollElement.scrollLeft -= step
+      syncCategoryScroll()
+    }
+
+    if (event.key === "ArrowRight") {
+      event.preventDefault()
+      scrollElement.scrollLeft += step
+      syncCategoryScroll()
+    }
   }
 
   // 按类别分组源
@@ -47,9 +212,38 @@ export function SourceSwitcher() {
   // 查找当前源名称
   const currentSourceData = findSourceByUrl(selectedSourceUrl)
   const currentSourceName = currentSourceData ? getSourceName(currentSourceData, locale) : t("sourceSwitcher.select")
+  const canScrollCategories = categoryScroll.maxScroll > 1
+  const categoryThumbWidth =
+    categoryScroll.scrollWidth > 0
+      ? Math.min(100, Math.max(16, (categoryScroll.clientWidth / categoryScroll.scrollWidth) * 100))
+      : 100
+  const categoryThumbLeft =
+    canScrollCategories
+      ? (categoryScroll.scrollLeft / categoryScroll.maxScroll) * (100 - categoryThumbWidth)
+      : 0
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return
+    }
+
+    syncCategoryScroll()
+
+    const scrollElement = categoryScrollRef.current
+    if (!scrollElement || typeof ResizeObserver === "undefined") {
+      return
+    }
+
+    const resizeObserver = new ResizeObserver(syncCategoryScroll)
+    resizeObserver.observe(scrollElement)
+
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [categoryEntries.length, locale, open, syncCategoryScroll])
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button variant="outline" role="combobox" aria-expanded={open} className="w-full md:w-[340px] justify-between">
           <span className="truncate">{currentSourceName}</span>
@@ -66,28 +260,67 @@ export function SourceSwitcher() {
             {t("sourceSwitcher.current")}: <span className="font-medium text-foreground">{currentSourceName}</span>
           </div>
           <div className="border-b px-2 py-2">
-            <div className="source-scroll flex max-h-24 flex-wrap gap-1 overflow-y-auto pb-2 md:max-h-none md:flex-nowrap md:overflow-x-auto md:overflow-y-hidden">
-              <Button
-                type="button"
-                variant={activeCategory === "all" ? "secondary" : "ghost"}
-                size="sm"
-                className="h-7 shrink-0 px-2 text-xs"
-                onClick={() => setActiveCategory("all")}
+            <div
+              className="source-category-region"
+              onMouseEnter={showCategoryScrollbar}
+              onMouseLeave={hideCategoryScrollbar}
+              onPointerEnter={showCategoryScrollbar}
+              onPointerLeave={hideCategoryScrollbar}
+            >
+              <div
+                ref={setCategoryScrollElement}
+                className="source-category-scroll flex max-h-24 flex-wrap gap-1 overflow-y-auto md:max-h-none md:flex-nowrap md:overflow-x-auto md:overflow-y-hidden"
+                onScroll={syncCategoryScroll}
               >
-                {t("sourceSwitcher.all")}
-              </Button>
-              {categoryEntries.map(([category, group]) => (
                 <Button
-                  key={category}
                   type="button"
-                  variant={activeCategory === category ? "secondary" : "ghost"}
+                  variant={activeCategory === "all" ? "secondary" : "ghost"}
                   size="sm"
                   className="h-7 shrink-0 px-2 text-xs"
-                  onClick={() => setActiveCategory(category)}
+                  onClick={() => setActiveCategory("all")}
                 >
-                  {group.label}
+                  {t("sourceSwitcher.all")}
                 </Button>
-              ))}
+                {categoryEntries.map(([category, group]) => (
+                  <Button
+                    key={category}
+                    type="button"
+                    variant={activeCategory === category ? "secondary" : "ghost"}
+                    size="sm"
+                    className="h-7 shrink-0 px-2 text-xs"
+                    onClick={() => setActiveCategory(category)}
+                  >
+                    {group.label}
+                  </Button>
+                ))}
+              </div>
+              {canScrollCategories && (
+                <div
+                  aria-label={t("sourceSwitcher.scrollCategories")}
+                  aria-orientation="horizontal"
+                  aria-valuemax={Math.round(categoryScroll.maxScroll)}
+                  aria-valuemin={0}
+                  aria-valuenow={Math.round(categoryScroll.scrollLeft)}
+                  className="source-category-scrollbar"
+                  data-dragging={isCategoryScrollbarDragging}
+                  data-visible={isCategoryScrollbarVisible || isCategoryScrollbarDragging}
+                  role="scrollbar"
+                  tabIndex={0}
+                  onKeyDown={handleCategoryScrollbarKeyDown}
+                  onPointerDown={handleCategoryScrollbarPointerDown}
+                  onPointerMove={handleCategoryScrollbarPointerMove}
+                  onPointerCancel={finishCategoryScrollbarPointer}
+                  onPointerUp={finishCategoryScrollbarPointer}
+                >
+                  <div
+                    className="source-category-scrollbar-thumb"
+                    style={{
+                      left: `${categoryThumbLeft}%`,
+                      width: `${categoryThumbWidth}%`,
+                    }}
+                  />
+                </div>
+              )}
             </div>
           </div>
           <CommandList className="source-scroll max-h-[40vh] pr-1 md:max-h-[360px]">

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -35,6 +35,9 @@ export function ThemeToggle() {
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"
+        onPointerDownOutside={() => {
+          closeFromPointerRef.current = true
+        }}
         onCloseAutoFocus={(event) => {
           if (!closeFromPointerRef.current) {
             return

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -33,6 +33,7 @@ const translations: Record<Locale, TranslationValue> = {
       empty: "未找到匹配的信息源",
       all: "全部",
       current: "当前",
+      scrollCategories: "滚动信息源类目",
     },
     feed: {
       emptyData: "数据为空，可能是由于该RSS源不稳定🫠",
@@ -70,6 +71,7 @@ const translations: Record<Locale, TranslationValue> = {
       empty: "No matching source found",
       all: "All",
       current: "Current",
+      scrollCategories: "Scroll source categories",
     },
     feed: {
       emptyData: "No data found. This RSS source may be unstable 🫠",

--- a/src/index.css
+++ b/src/index.css
@@ -115,6 +115,44 @@ body {
     background: hsl(var(--muted-foreground) / 0.52);
   }
 
+  .source-category-scroll {
+    scrollbar-width: none;
+  }
+
+  .source-category-scroll::-webkit-scrollbar {
+    display: none;
+  }
+
+  .source-category-scrollbar {
+    @apply relative mt-2 h-2 w-full cursor-default rounded-full outline-none;
+    background: hsl(var(--muted) / 0.7);
+    opacity: 0;
+    transition: opacity 160ms ease;
+  }
+
+  .source-category-scrollbar[data-visible="true"],
+  .source-category-region:hover .source-category-scrollbar,
+  .source-category-region:focus-within .source-category-scrollbar,
+  .source-category-scrollbar[data-dragging="true"] {
+    opacity: 1;
+  }
+
+  .source-category-scrollbar:focus-visible {
+    box-shadow:
+      0 0 0 2px hsl(var(--popover)),
+      0 0 0 4px hsl(var(--ring) / 0.72);
+  }
+
+  .source-category-scrollbar-thumb {
+    @apply absolute top-1/2 h-1.5 -translate-y-1/2 rounded-full transition-colors;
+    background: hsl(var(--muted-foreground) / 0.46);
+  }
+
+  .source-category-scrollbar:hover .source-category-scrollbar-thumb,
+  .source-category-scrollbar:focus-visible .source-category-scrollbar-thumb {
+    background: hsl(var(--muted-foreground) / 0.64);
+  }
+
   .dark .feed-card {
     @apply bg-card border-border;
     box-shadow:


### PR DESCRIPTION
## Summary
- prevent right-side dropdown triggers from keeping a focus ring after pointer close
- replace the hidden native category overflow with a styled horizontal scrollbar
- remember the source category horizontal scroll position across popover reopen

## Verification
- pnpm typecheck
- pnpm build
- browser verified: category scrollLeft persists after close/reopen; source list vertical scroll resets after reopen