### PR TITLE
Fix selected feed card accent overflow

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -119,12 +119,19 @@ body {
   .feed-card::before {
     content: "";
     position: absolute;
-    top: 0;
+    top: 1px;
     left: 0;
-    bottom: 0;
+    bottom: 1px;
     width: 2px;
-    border-radius: 999px;
-    background: var(--feed-card-selected-line);
+    border-radius: var(--radius) 0 0 var(--radius);
+    clip-path: inset(0 0 0 0 round var(--radius) 0 0 var(--radius));
+    background: linear-gradient(
+      to bottom,
+      transparent 0,
+      var(--feed-card-selected-line) calc(var(--radius) + 1px),
+      var(--feed-card-selected-line) calc(100% - var(--radius) - 1px),
+      transparent 100%
+    );
     opacity: 0;
     transform: scaleY(0.72);
     transform-origin: center;
@@ -138,15 +145,15 @@ body {
     transform: scaleY(1);
   }
 
-  .feed-card:hover::before {
-    background: var(--feed-card-hover-line);
+  .feed-card:not(.feed-card-selected):hover::before {
+    --feed-card-selected-line: var(--feed-card-hover-line);
     opacity: 0.72;
     transform: scaleY(1);
   }
 
   .feed-card-selected:hover::before {
-    background: var(--feed-card-selected-line);
     opacity: 1;
+    transform: scaleY(1);
   }
 
   .source-scroll {


### PR DESCRIPTION
## Summary
- refine the selected feed-card accent line so it follows the card radius without overflowing
- keep selected accent styling stable between hover and non-hover states

## Tests
- pnpm typecheck
- pnpm build
- git diff --check