### PR TITLE
feat: add Sebastian Raschka blog feed

### DIFF
--- a/src/config/feedme.config.yaml
+++ b/src/config/feedme.config.yaml
@@ -120,6 +120,12 @@ sources:
       en: Ruanyifeng's Blog
     url: http://www.ruanyifeng.com/blog/atom.xml
     category: personalBlogs
+  - id: sebastian-raschka
+    name:
+      zh: Sebastian Raschka
+      en: Sebastian Raschka
+    url: https://sebastianraschka.com/rss_feed.xml
+    category: personalBlogs
   - id: openai-news
     name:
       zh: OpenAI News


### PR DESCRIPTION
## Summary
- add Sebastian Raschka's RSS feed to the Personal Blogs category
- provide localized display names using the existing configuration schema

## Verification
- confirmed the feed returns HTTP 200 and parses as RSS 2.0
- parsed 139 feed items with the project's RSS parser
- pnpm typecheck
- pnpm build