### PR TITLE
fix: repair broken star history chart

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -220,10 +220,10 @@ This project uses Node.js 24 LTS. Use `.nvmrc` or `.node-version` to switch auto
 
 ## Star History
 
-<a href="https://www.star-history.com/#Seanium/FeedMe&Date">
+<a href="https://star-history.dera.page/#Seanium/FeedMe&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Seanium/FeedMe&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Seanium/FeedMe&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Seanium/FeedMe&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Seanium/FeedMe&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Seanium/FeedMe&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Seanium/FeedMe&type=Date" />
  </picture>
 </a>

--- a/README.md
+++ b/README.md
@@ -220,10 +220,10 @@ GitHub Actions 每次构建后会自动推送到 `deploy` 分支，阿里云 ESA
 
 ## Star 趋势
 
-<a href="https://www.star-history.com/#Seanium/FeedMe&Date">
+<a href="https://star-history.dera.page/#Seanium/FeedMe&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Seanium/FeedMe&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Seanium/FeedMe&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Seanium/FeedMe&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Seanium/FeedMe&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Seanium/FeedMe&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Seanium/FeedMe&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart on the project page is currently broken due to GitHub stargazer API restrictions. This change points it to a reliable alternative that serves both the chart and its frontend from a single domain without requiring an API token, restoring the chart for all visitors.